### PR TITLE
Use options from props instead of state

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ var Component = React.createClass({
                                 onValueChange={(option) => this.setState({selectedOption: option})}
                                 >
                                 {this.props.options.map((option, i) => {
-                                    var label = this.state.labels[i] || option;
+                                    var label = this.props.labels[i] || option;
                                     return (
                                         <PickerItemIOS
                                             key={option}

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var Component = React.createClass({
                                 selectedValue={this.state.selectedOption}
                                 onValueChange={(option) => this.setState({selectedOption: option})}
                                 >
-                                {this.state.options.map((option, i) => {
+                                {this.props.options.map((option, i) => {
                                     var label = this.state.labels[i] || option;
                                     return (
                                         <PickerItemIOS


### PR DESCRIPTION
Using options from props instead of state means that if the parent components changes the options list, these options will be updated too. At the moment, the options are assigned to initial state, so if the options do change, this is not reflected in the picker.

Also, `this.state.options` is never changed, so I am pretty sure this shouldn't break anything?
