### PR TITLE
Upgrade rn26

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var Component = React.createClass({
     render: function() {
         return (
             <Modal
-                animated={true}
+                animationType={'slide'}
                 transparent={true}
                 visible={this.state.modalVisible}>
                 <View style={styles.basicContainer}>


### PR DESCRIPTION
This upgrades FMPicker modal for React Native 0.26.0

React Native 26 Deprecated `animated` and now uses `animationType` which accepts `'none', 'slide', 'fade'`
